### PR TITLE
Update: Initiating pool connection early with configure

### DIFF
--- a/src/core/miner_session.py
+++ b/src/core/miner_session.py
@@ -816,7 +816,7 @@ class MinerSession:
 
             # Poor acceptance rate
             total_shares = self.stats.accepted + self.stats.rejected
-            if total_shares > 0 and total_shares % 1000 == 0:
+            if total_shares > 0 and total_shares % 250 == 0:
                 acceptance_rate = (self.stats.accepted / total_shares) * 100
                 
                 if acceptance_rate < 30:

--- a/src/core/miner_session.py
+++ b/src/core/miner_session.py
@@ -103,7 +103,7 @@ class MinerSession:
         has_authorize = False
         authorize_time = None
         
-        AUTHORIZE_TIMEOUT = 1
+        AUTHORIZE_TIMEOUT = 0.3
         POST_AUTHORIZE_WAIT = 0.2
         
         start_time = time.time()
@@ -204,6 +204,12 @@ class MinerSession:
 
             for task in pending:
                 task.cancel()
+            
+            for task in pending:
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
         except Exception as e:
             logger.error(f"[{self.miner_id}] Session error: {e}")

--- a/src/core/miner_session.py
+++ b/src/core/miner_session.py
@@ -103,7 +103,7 @@ class MinerSession:
         has_authorize = False
         authorize_time = None
         
-        AUTHORIZE_TIMEOUT = 0.4
+        AUTHORIZE_TIMEOUT = 0.7
         POST_AUTHORIZE_WAIT = 0.2
         
         start_time = time.time()

--- a/src/core/miner_session.py
+++ b/src/core/miner_session.py
@@ -103,7 +103,7 @@ class MinerSession:
         has_authorize = False
         authorize_time = None
         
-        AUTHORIZE_TIMEOUT = 0.3
+        AUTHORIZE_TIMEOUT = 0.4
         POST_AUTHORIZE_WAIT = 0.2
         
         start_time = time.time()


### PR DESCRIPTION
- Now we fire off the pool connection if:
     - We get a configure
     - We get authorize later on

Instead of only authorize previously. This handles some versions of miners who have older firmware and require synchronous handshakes. 
It should be backwards compatible as well - waiting for feedback from the community 