### PR TITLE
Feat: Disconnect bad miners

### DIFF
--- a/src/core/miner_session.py
+++ b/src/core/miner_session.py
@@ -387,6 +387,22 @@ class MinerSession:
                 f"[{self.miner_id}] {submit_data['worker']} - Share rejected ({reason}): "
                 f"diff={actual_difficulty:.2f}"
             )
+        
+        # Check acceptance ratio every 250 shares
+        total_shares = self.stats.accepted + self.stats.rejected
+        if total_shares > 0 and total_shares % 250 == 0:
+            acceptance_rate = (self.stats.accepted / total_shares) * 100
+            
+            if acceptance_rate < 30:
+                logger.warning(
+                    f"[{self.miner_id}] {submit_data.get('worker', 'unknown')} - "
+                    f"Disconnecting: {acceptance_rate:.1f}% acceptance rate "
+                    f"({self.stats.accepted}/{total_shares} accepted)"
+                )
+                
+                # Close the miner connection
+                self.miner_writer.close()
+                await self.miner_writer.wait_closed()
 
     async def _cleanup(self):
         """Clean up resources on disconnect."""


### PR DESCRIPTION
- We saw through nice hash, there are bad miners who hog up the system by consistently submitting bad shares. 
- Either they have their firmware tweaked or have bad network. They are mostly submitting shares for jobs which dont exist (these jobs have been updated a while back)
- This change checks every 250 shares if their acceptance rate is less than 30%. If it is, we disconnect the connection. 
- This ensure good miners are connected and our resources are not hogged down. 
<img width="696" height="375" alt="image" src="https://github.com/user-attachments/assets/d08ccfd5-9601-44bc-ab85-070c26b953d4" />
