### PR TITLE
Update/accurate sampling time

### DIFF
--- a/src/core/miner_session.py
+++ b/src/core/miner_session.py
@@ -8,6 +8,7 @@ calculation, and state transitions.
 
 import asyncio
 import json
+from datetime import datetime, timezone
 from typing import Optional, Any, Dict
 
 from ..utils.logger import get_logger, log_stratum_message
@@ -177,6 +178,7 @@ class MinerSession:
                         )
 
                     elif method == "mining.submit":
+                        share_received_at = datetime.now(timezone.utc)
                         params = message.get("params", [])
                         if len(params) >= 5 and msg_id is not None:
                             submit_data = {
@@ -186,6 +188,7 @@ class MinerSession:
                                 "ntime": params[3],
                                 "nonce": params[4],
                                 "version": params[5] if len(params) > 5 else None,
+                                "received_at": share_received_at,
                             }
                             self.pending_submits[msg_id] = submit_data
                             logger.debug(
@@ -368,6 +371,7 @@ class MinerSession:
                     block_hash=block_hash if "block_hash" in locals() else "",
                     pool_requested_difficulty=self.pool_difficulty,
                     pool_label=self.pool_label,
+                    share_timestamp=submit_data.get("received_at"),
                 )
             except Exception as e:
                 logger.error(f"[{self.miner_id}] Failed to insert share: {e}")

--- a/src/storage/db.py
+++ b/src/storage/db.py
@@ -1,4 +1,6 @@
 import os
+from datetime import datetime, timezone
+from typing import Optional
 
 import clickhouse_connect
 import urllib3
@@ -387,6 +389,7 @@ class StatsDB:
         pool_difficulty: float,
         actual_difficulty: float,
         block_hash: str = "",
+        share_timestamp: Optional[datetime] = None,
         **kwargs,
     ) -> None:
         """
@@ -399,16 +402,19 @@ class StatsDB:
             pool_difficulty: Pool difficulty
             actual_difficulty: Actual share difficulty
             block_hash: Block hash (will be reversed before storage)
+            share_timestamp: Timestamp when share was received
         """
         if not self.client:
             logger.error("ClickHouse client is not initialised")
             return
 
+        ts = share_timestamp or datetime.now(timezone.utc)
         try:
             await self.client.insert(
                 "shares",
                 [
                     [
+                        ts,
                         miner,
                         worker,
                         pool,
@@ -420,6 +426,7 @@ class StatsDB:
                     ]
                 ],
                 column_names=[
+                    "ts",
                     "miner",
                     "worker",
                     "pool",


### PR DESCRIPTION
- Updates share timestamp to be more accurate (vs previously, there was a tolerance of 10 seconds due to async inserts time)
- Avoids spikes by ensuring sampling is done over share received time