### PR TITLE
Feat/payout transactions

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -212,6 +212,7 @@ class TidesRewardSummary(BaseModel):
     btc_amount: float = Field(description="BTC reward amount")
     confirmed_at: datetime = Field(description="When the transaction was confirmed")
     processed: bool = Field(description="Whether this reward has been processed")
+    source_type: str = Field(description="Source of reward: 'coinbase' or 'pool_payout'")
 
     @field_serializer("confirmed_at", when_used="json")
     def _serialize_confirmed_at(self, v: datetime) -> str:
@@ -271,6 +272,7 @@ class TidesRewardDetails(BaseModel):
     )
     processed: bool = Field(description="Whether this reward has been processed")
     updated_at: datetime = Field(description="Last update timestamp")
+    source_type: str = Field(description="Source of reward: 'coinbase' or 'pool_payout'")
 
     @field_serializer("confirmed_at", "discovered_at", "updated_at", when_used="json")
     def _serialize_reward_datetimes(self, v: datetime) -> str:
@@ -315,6 +317,7 @@ class CustomTidesRewardResponse(BaseModel):
         description="TIDES window data at time of discovery"
     )
     processed: bool = Field(description="Whether this reward has been processed")
+    source_type: str = Field(description="Source of reward: 'coinbase' or 'pool_payout'")
 
     @field_serializer("confirmed_at", "discovered_at", when_used="json")
     def _serialize_custom_reward_datetimes(self, v: datetime) -> str:

--- a/src/api/services/tides_rewards_queries.py
+++ b/src/api/services/tides_rewards_queries.py
@@ -20,7 +20,8 @@ async def get_all_tides_rewards(db: StatsDB) -> List[dict[str, Any]]:
         tx_hash,
         btc_amount,
         confirmed_at,
-        processed
+        processed,
+        source_type
     FROM tides_rewards
     ORDER BY confirmed_at DESC
     """
@@ -34,6 +35,7 @@ async def get_all_tides_rewards(db: StatsDB) -> List[dict[str, Any]]:
             "btc_amount": float(row[1]),
             "confirmed_at": row[2],
             "processed": bool(row[3]),
+            "source_type": row[4],
         })
     
     return rewards
@@ -51,7 +53,8 @@ async def get_tides_reward_by_tx_hash(db: StatsDB, tx_hash: str) -> Optional[dic
         discovered_at,
         tides_window,
         processed,
-        updated_at
+        updated_at,
+        source_type
     FROM tides_rewards
     WHERE tx_hash = %(tx_hash)s
     LIMIT 1
@@ -82,6 +85,7 @@ async def get_tides_reward_by_tx_hash(db: StatsDB, tx_hash: str) -> Optional[dic
         "tides_window": tides_window_data,
         "processed": bool(row[6]),
         "updated_at": row[7],
+        "source_type": row[8],
     }
 
 
@@ -186,11 +190,11 @@ async def create_tides_reward(
     insert_query = """
     INSERT INTO tides_rewards (
         tx_hash, block_height, btc_amount, 
-        confirmed_at, discovered_at, tides_window
+        confirmed_at, discovered_at, tides_window, source_type
     )
     VALUES (
         %(tx_hash)s, %(block_height)s, %(btc_amount)s, 
-        %(confirmed_at)s, %(discovered_at)s, %(tides_window)s
+        %(confirmed_at)s, %(discovered_at)s, %(tides_window)s, %(source_type)s
     )
     """
     
@@ -201,6 +205,7 @@ async def create_tides_reward(
         "confirmed_at": confirmed_at,
         "discovered_at": confirmed_at,
         "tides_window": tides_window_json,
+        "source_type": "pool_payout",
     }
     
     await db.client.command(insert_query, parameters=params)

--- a/src/api/services/tides_rewards_queries.py
+++ b/src/api/services/tides_rewards_queries.py
@@ -220,4 +220,5 @@ async def create_tides_reward(
         "discovered_at": confirmed_at,
         "tides_window": tides_window,
         "processed": False,
+        "source_type": "pool_payout",
     }

--- a/src/storage/db.py
+++ b/src/storage/db.py
@@ -133,6 +133,11 @@ class StatsDB:
                 "ALTER TABLE daily_rewards ADD COLUMN payment_proof_url String DEFAULT ''",
                 "Add payment_proof_url field for storing payment documentation links",
             ),
+            (
+                15,
+                "ALTER TABLE tides_rewards ADD COLUMN source_type LowCardinality(String) DEFAULT 'pool_payout'",
+                "Add source_type column to distinguish coinbase vs pool_payout rewards",
+            ),
         ]
 
         for version, migration_sql, description in migrations:

--- a/src/tides_monitoring/rewards_monitor.py
+++ b/src/tides_monitoring/rewards_monitor.py
@@ -413,6 +413,15 @@ async def tides_rewards_monitor_task(db: StatsDB) -> None:
                         )
                         continue
 
+                    try:
+                        source_type = await classify_transaction(tx_hash, ocean_client, client)
+                        if not source_type:
+                            logger.debug(f"Skipping non-mining transaction {tx_hash}")
+                            continue
+                    except Exception as e:
+                        logger.error(f"Failed to classify transaction {tx_hash}: {e}")
+                        continue
+
                     tides_window = await get_tides_window(db)
                     normalized_window = (
                         normalize_tides_window_snapshot(tides_window)

--- a/src/tides_monitoring/rewards_monitor.py
+++ b/src/tides_monitoring/rewards_monitor.py
@@ -235,6 +235,102 @@ class BlockCypherClient:
             logger.error(f"Failed to fetch transactions for {self.btc_address}: {e}")
             raise
 
+    @retry(
+        stop=stop_after_attempt(10),
+        wait=wait_exponential(multiplier=2, min=1, max=10),
+        reraise=True,
+    )
+    async def get_tx_details(self, tx_hash: str) -> Dict:
+        """Fetch full transaction details for a tx hash."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.api_base}/txs/{tx_hash}",
+                    timeout=aiohttp.ClientTimeout(total=20),
+                ) as response:
+                    if response.status == 200:
+                        return await response.json()
+                    else:
+                        logger.error(
+                            f"BlockCypher TX API HTTP error {response.status} for {tx_hash}"
+                        )
+                        raise aiohttp.ClientResponseError(
+                            request_info=response.request_info,
+                            history=response.history,
+                            status=response.status,
+                        )
+        except Exception as e:
+            logger.error(f"Failed to fetch tx details for {tx_hash}: {e}")
+            raise
+
+
+class OceanAPIClient:
+    """Client for interacting with Ocean.xyz API."""
+
+    def __init__(self, btc_address: str):
+        self.btc_address = btc_address
+        self.api_base = "https://api.ocean.xyz/v1"
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=2, min=1, max=5),
+        reraise=True,
+    )
+    async def get_payouts(self) -> Dict:
+        """Fetch payout data for the BTC address."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.api_base}/earnpay/{self.btc_address}",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        logger.debug(f"Retrieved Ocean payouts for {self.btc_address}")
+                        return data
+                    else:
+                        logger.error(f"Ocean API HTTP error: {response.status}")
+                        raise aiohttp.ClientResponseError(
+                            request_info=response.request_info,
+                            history=response.history,
+                            status=response.status,
+                        )
+        except Exception as e:
+            logger.error(f"Failed to fetch Ocean payouts for {self.btc_address}: {e}")
+            raise
+
+
+async def classify_transaction(
+    tx_hash: str, ocean_client: OceanAPIClient, blockcypher_client: BlockCypherClient
+) -> Optional[str]:
+    """
+    Classify transaction as coinbase or pool_payout using Ocean API + BlockCypher fallback.
+
+    Returns:
+        'coinbase': Coinbase transaction (mining reward)
+        'pool_payout': Pool payout transaction
+        None: Regular transaction, should be skipped
+    """
+    # Step 1: Check Ocean
+    try:
+        ocean_data = await ocean_client.get_payouts()
+        for payout in ocean_data["result"]["payouts"]:
+            if payout["on_chain_txid"] == tx_hash:
+                return "coinbase" if payout["is_generation_txn"] else "pool_payout"
+    except Exception as e:
+        logger.warning(f"Ocean API failed for {tx_hash}: {e}")
+
+    # Step 2: Check tx_deets for coinbase
+    try:
+        tx_details = await blockcypher_client.get_tx_details(tx_hash)
+        if tx_details.get("block_index") == 0:
+            return "coinbase"
+    except Exception as e:
+        logger.warning(f"BlockCypher tx details failed for {tx_hash}: {e}")
+
+    # Step 3: Skip unknown transactions
+    return None
+
 
 async def tides_rewards_monitor_task(db: StatsDB) -> None:
     """
@@ -266,6 +362,7 @@ async def tides_rewards_monitor_task(db: StatsDB) -> None:
         return
 
     client = BlockCypherClient(btc_address)
+    ocean_client = OceanAPIClient(btc_address)
 
     logger.info(
         f"Starting TIDES rewards monitoring for {btc_address} "
@@ -285,7 +382,7 @@ async def tides_rewards_monitor_task(db: StatsDB) -> None:
 
             for tx in transactions:
                 if (
-                    tx.get("tx_input_n") == -1  # Coinbase transaction
+                    tx.get("tx_input_n") == -1  # Address received funds
                     and tx.get("confirmed")  # Has confirmation date
                     and tx.get("block_height")
                 ):
@@ -327,11 +424,11 @@ async def tides_rewards_monitor_task(db: StatsDB) -> None:
                     insert_query = """
                     INSERT INTO tides_rewards (
                         tx_hash, block_height, btc_amount, 
-                        confirmed_at, discovered_at, tides_window
+                        confirmed_at, discovered_at, tides_window, source_type
                     )
                     VALUES (
                         %(tx_hash)s, %(block_height)s, %(btc_amount)s, 
-                        %(confirmed_at)s, %(discovered_at)s, %(snapshot)s
+                        %(confirmed_at)s, %(discovered_at)s, %(snapshot)s, %(source_type)s
                     )
                     """
 
@@ -347,10 +444,11 @@ async def tides_rewards_monitor_task(db: StatsDB) -> None:
                         "confirmed_at": confirmed_at,
                         "discovered_at": confirmed_at,
                         "snapshot": snapshot_json,
+                        "source_type": source_type,
                     }
 
                     await db.client.command(insert_query, parameters=params)
-                    # TODO: Enable when processing these earnings. 
+                    # TODO: Enable when processing these earnings.
                     # await process_tides_reward_earnings(
                     #     db, tx_hash, btc_amount, normalized_window, confirmed_at
                     # )


### PR DESCRIPTION
- Adds `source_type` for block rewards  - either coinbase or pool_payout
- Backfills current rewards (only 1 exist in prod)
- Adds Ocean client to confirm pool_payout transactions
- Adds transaction details endpoint for block_cypher to confirm coinbase txs 
- Adds `classify_transaction` when processing rewards