### PR TITLE
Add support for multiple tides tx hashes

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1593,7 +1593,7 @@ async def create_batch_payout(
         "payment_method": "bitcoin",
         "notes": "Weekly payout",
         "admin_override": false,
-        "tides_tx_hash": "optional_reward_to_mark_processed"
+        "tides_tx_hashes": ["hash1", "hash2"],
     }
     """
     if not db or not db.client:
@@ -1617,7 +1617,7 @@ async def create_batch_payout(
             payout_request.payment_method,
             payout_request.notes,
             payout_request.admin_override,
-            payout_request.tides_tx_hash,
+            payout_request.tides_tx_hashes,
             "api_admin",
         )
 
@@ -1627,6 +1627,7 @@ async def create_batch_payout(
                 batch_id=result["batch_id"],
                 total_amount=result["total_amount"],
                 processed_workers=result["processed_workers"],
+                tides_rewards_processed=result.get("tides_rewards_processed"),
                 admin_override_used=result.get("admin_override_used"),
                 error=None,
                 negative_balance_warnings=result.get("negative_balance_warnings"),
@@ -1638,6 +1639,7 @@ async def create_batch_payout(
                 batch_id=None,
                 total_amount=None,
                 processed_workers=None,
+                tides_rewards_processed=None,
                 admin_override_used=False,
                 error=result["error"],
                 negative_balance_warnings=result.get("negative_balance_warnings"),

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -212,7 +212,9 @@ class TidesRewardSummary(BaseModel):
     btc_amount: float = Field(description="BTC reward amount")
     confirmed_at: datetime = Field(description="When the transaction was confirmed")
     processed: bool = Field(description="Whether this reward has been processed")
-    source_type: str = Field(description="Source of reward: 'coinbase' or 'pool_payout'")
+    source_type: str = Field(
+        description="Source of reward: 'coinbase' or 'pool_payout'"
+    )
 
     @field_serializer("confirmed_at", when_used="json")
     def _serialize_confirmed_at(self, v: datetime) -> str:
@@ -272,7 +274,9 @@ class TidesRewardDetails(BaseModel):
     )
     processed: bool = Field(description="Whether this reward has been processed")
     updated_at: datetime = Field(description="Last update timestamp")
-    source_type: str = Field(description="Source of reward: 'coinbase' or 'pool_payout'")
+    source_type: str = Field(
+        description="Source of reward: 'coinbase' or 'pool_payout'"
+    )
 
     @field_serializer("confirmed_at", "discovered_at", "updated_at", when_used="json")
     def _serialize_reward_datetimes(self, v: datetime) -> str:
@@ -317,7 +321,9 @@ class CustomTidesRewardResponse(BaseModel):
         description="TIDES window data at time of discovery"
     )
     processed: bool = Field(description="Whether this reward has been processed")
-    source_type: str = Field(description="Source of reward: 'coinbase' or 'pool_payout'")
+    source_type: str = Field(
+        description="Source of reward: 'coinbase' or 'pool_payout'"
+    )
 
     @field_serializer("confirmed_at", "discovered_at", when_used="json")
     def _serialize_custom_reward_datetimes(self, v: datetime) -> str:

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -402,8 +402,8 @@ class BatchPayoutRequest(BaseModel):
     admin_override: bool = Field(
         default=False, description="Allow negative balances if true"
     )
-    tides_tx_hash: Optional[str] = Field(
-        None, description="TIDES reward to mark as processed"
+    tides_tx_hashes: Optional[List[str]] = Field(
+        None, description="TIDES rewards to mark as processed"
     )
 
 
@@ -423,6 +423,9 @@ class BatchPayoutResponse(BaseModel):
     batch_id: Optional[str] = Field(description="Created batch ID")
     total_amount: Optional[float] = Field(description="Total BTC amount in batch")
     processed_workers: Optional[int] = Field(description="Number of workers processed")
+    tides_rewards_processed: Optional[int] = Field(
+        description="Number of TIDES rewards marked as processed"
+    )
     admin_override_used: Optional[bool] = Field(
         description="Whether admin override was used"
     )

--- a/src/storage/db.py
+++ b/src/storage/db.py
@@ -379,6 +379,7 @@ class StatsDB:
                 discovered_at DateTime DEFAULT now(),
                 tides_window String,
                 processed Boolean DEFAULT false,
+                source_type LowCardinality(String) DEFAULT 'pool_payout',
                 updated_at DateTime DEFAULT now()
             ) ENGINE = ReplacingMergeTree(updated_at)
             ORDER BY (block_height, tx_hash)""",


### PR DESCRIPTION
- Updates batch payout API to support multiple tides tx hashes. 
- Error out fast if any tx_hash is invalid (i.e. doesnt exist)